### PR TITLE
Add fuzzing by way of ClusterFuzzLite

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,6 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool
+
+COPY . $SRC/ejson4cpp
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+WORKDIR $SRC/ejson4cpp

--- a/.clusterfuzzlite/README.md
+++ b/.clusterfuzzlite/README.md
@@ -1,0 +1,2 @@
+# ClusterFuzzLite set up
+This folder contains a fuzzing set for [ClusterFuzzLite](https://google.github.io/clusterfuzzlite).

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -eu
+
+mkdir build
+cd build
+export CXXFLAGS="${CXXFLAGS} -std=gnu++17"
+cmake ../
+make
+
+# Copy all fuzzer executables to $OUT/
+$CXX $CXXFLAGS $LIB_FUZZING_ENGINE \
+  $SRC/ejson4cpp/.clusterfuzzlite/fromjson_fuzzer.cpp \
+  -o $OUT/fromjson_fuzzer \
+  $SRC/ejson4cpp/build/libejson.a \
+  -I$SRC/ejson4cpp/src/

--- a/.clusterfuzzlite/fromjson_fuzzer.cpp
+++ b/.clusterfuzzlite/fromjson_fuzzer.cpp
@@ -1,0 +1,26 @@
+#include <string>
+
+#include "ejson/parser.h"
+
+struct person
+{
+   std::string name;
+   int         id{};
+   double      val;
+};
+
+AUTO_GEN_NON_INTRUSIVE(person, name, id, val)
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+   std::string fuzz_input(reinterpret_cast<const char *>(data), size);
+   person      p;
+   try
+   {
+      ejson::Parser::FromJSON(fuzz_input.c_str(), p);
+   }
+   catch (...)
+   {
+   }
+   return 0;
+}

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c++

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -2,7 +2,7 @@ name: ClusterFuzzLite PR fuzzing
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ main ]
+    branches: [ master ]
 permissions: read-all
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ main ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

I added a fuzzer that targets `ejson::Parser::FromJSON` and currently set the timeout of CFLite to 100 seconds. CFLite will flag if the fuzzer finds  any issues in the code introduced by a PR.

To reproduce this set up the way ClusterFuzzLite does it (by way of [OSS-Fuzz](https://github.com/google/oss)) you can do:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/ejson4cpp
cd ejson4cpp
git checkout clusterfuzzlite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD doc_fuzzer-- -max_total_time=10
```